### PR TITLE
Fixed comment for references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Just don't do it. No referencing makes for easy tracking of changes and helps to
 E.g.,
 
   ```php
-  function yoMamma(Model &$model) {
+  function yoMamma(array &$allModel) {
     // Something here.
   }
   ```


### PR DESCRIPTION
The example for `Never use references` was incorrect. It used a `Model`, hence an object. Objects are _always_ passed as reference in PHP. Only scalar types (int, array, bool) etc can be passed by value.